### PR TITLE
Pretty compact form

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2398,7 +2398,7 @@
          (update-in norm [1 :aliases] (fn [old]
                                         (when old
                                           (-fail! ::aliases-property-already-exists))
-                                        (reduce-kv (fn [m k v] (assoc m (keyword k) (keyword v))) {} aliases))))
+                                        (reduce-kv (fn [m k v] (assoc m (keyword v) (keyword k))) {} aliases))))
        f))))
 
 (defn properties

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2383,7 +2383,6 @@
    (let [state (atom {})
          f (-compact-form (schema ?schema options) (assoc options ::compact {:aliases aliases :state state :raliases (set/map-invert aliases)}))
          {:keys [used abandoned]} @state]
-     (prn "used" used aliases (keys used))
      (if-some [aliases (when-not abandoned (not-empty (select-keys aliases (keys used))))]
        (let [norm (if (vector? f)
                     (if (= (count f) 1)

--- a/src/malli/dev/pretty.cljc
+++ b/src/malli/dev/pretty.cljc
@@ -188,3 +188,8 @@
   ([?schema value options]
    (let [explain (fn [] (->> (m/explain ?schema value options) (me/with-error-messages)))]
      ((prettifier ::m/explain "Validation Error" explain options)))))
+
+(defn print-schema
+  ([]))
+
+#?(:clj (defmethod print-method ::m/schema [v ^java.io.Writer w] (.write w (pr-str (-form ^Schema v)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3606,6 +3606,7 @@
   (binding [*ns* (the-ns this-nsym)]
     (is (= [:tuple
             {:aliases {:_ :malli.core-test, :mg :malli.generator}
+             :malli.core-test/property :malli.core-test/not-aliased,
              :registry {:_/a [:ref :_/b],
                         :_/b :mg/gen,
                         :mg/gen :_/a}}
@@ -3613,6 +3614,7 @@
            (m/compact-form [:tuple
                             {:registry {::a [:ref ::b]
                                         ::b ::mg/gen
-                                        ::mg/gen ::a}}
+                                        ::mg/gen ::a}
+                             ::property ::not-aliased}
                             ::a ::b]))))
   )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3604,11 +3604,15 @@
   (binding [*ns* (the-ns this-nsym)]
     (is (= :any (m/compact-form :any))))
   (binding [*ns* (the-ns this-nsym)]
-    (is (= [:schema
-            {:aliases {:malli.core-test :_}
-             :registry {:_/a [:ref :_/b], :_/b :any}}
-            [:tuple :_/a :_/b]]
-           (m/compact-form [:schema {:registry {::a [:ref ::b]
-                                                ::b :any}}
-                            [:tuple ::a ::b]]))))
+    (is (= [:tuple
+            {:aliases {:malli.core-test :_, :malli.generator :mg}
+             :registry {:_/a [:ref :_/b],
+                        :_/b :mg/gen,
+                        :mg/gen :_/a}}
+            :_/a :_/b]
+           (m/compact-form [:tuple
+                            {:registry {::a [:ref ::b]
+                                        ::b ::mg/gen
+                                        ::mg/gen ::a}}
+                            ::a ::b]))))
   )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3617,4 +3617,19 @@
                                         ::mg/gen ::a}
                              ::property ::not-aliased}
                             ::a ::b]))))
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= [:tuple
+            {:registry {::a [:ref ::b]
+                        ::b ::mg/gen
+                        ::mg/gen ::a}
+             ::property ::not-aliased}
+            ::a ::b]
+           (m/form
+             (m/schema
+               (m/compact-form [:tuple
+                                {:registry {::a [:ref ::b]
+                                            ::b ::mg/gen
+                                            ::mg/gen ::a}
+                                 ::property ::not-aliased}
+                                ::a ::b]))))))
   )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3605,7 +3605,7 @@
     (is (= :any (m/compact-form :any))))
   (binding [*ns* (the-ns this-nsym)]
     (is (= [:tuple
-            {:aliases {:malli.core-test :_, :malli.generator :mg}
+            {:aliases {:_ :malli.core-test, :mg :malli.generator}
              :registry {:_/a [:ref :_/b],
                         :_/b :mg/gen,
                         :mg/gen :_/a}}

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3604,7 +3604,11 @@
   (binding [*ns* (the-ns this-nsym)]
     (is (= :any (m/compact-form :any))))
   (binding [*ns* (the-ns this-nsym)]
-    (is (= :any (m/compact-form [:schema {:registry {::a [:ref ::b]
-                                                     ::b :any}}
-                                 [:tuple ::a ::b]]))))
+    (is (= [:schema
+            {:aliases {:malli.core-test :_}
+             :registry {:_/a [:ref :_/b], :_/b :any}}
+            [:tuple :_/a :_/b]]
+           (m/compact-form [:schema {:registry {::a [:ref ::b]
+                                                ::b :any}}
+                            [:tuple ::a ::b]]))))
   )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3603,4 +3603,8 @@
     (is (= :_/foo (m/compact-form (m/-proxy-schema {:type :_/foo :fn (fn [_ _ _] [[] [] (m/schema :any)])})))))
   (binding [*ns* (the-ns this-nsym)]
     (is (= :any (m/compact-form :any))))
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= :any (m/compact-form [:schema {:registry {::a [:ref ::b]
+                                                     ::b :any}}
+                                 [:tuple ::a ::b]]))))
   )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3581,3 +3581,26 @@
   (is (not (m/validate [:sequential {:min 11} :int] (eduction identity (range 10)))))
   (is (not (m/validate [:seqable {:min 11} :int] (eduction identity (range 10)))))
   (is (nil? (m/explain [:sequential {:min 9} :int] (eduction identity (range 10))))))
+
+(def this-nsym (ns-name *ns*))
+
+(deftest compact-form-test
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= [:schema {:aliases {:_ :malli.core-test}} :_/foo]
+           (m/compact-form (m/-proxy-schema {:type ::foo :fn (fn [_ _ _] [[] [] (m/schema :any)])})))))
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= [:schema {:aliases {:_ :malli.core-test}} [:tuple :_/foo :_/bar]]
+           (m/compact-form [:tuple
+                            (m/-proxy-schema {:type ::foo :fn (fn [_ _ _] [[] [] (m/schema :any)])})
+                            (m/-proxy-schema {:type ::bar :fn (fn [_ _ _] [[] [] (m/schema :any)])})]))))
+  ;;FIXME don't alias if ambiguous
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= [:tuple ::foo :_/foo]
+           (m/compact-form [:tuple
+                            (m/-proxy-schema {:type ::foo :fn (fn [_ _ _] [[] [] (m/schema :any)])})
+                            (m/-proxy-schema {:type :_/foo :fn (fn [_ _ _] [[] [] (m/schema :any)])})]))))
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= :_/foo (m/compact-form (m/-proxy-schema {:type :_/foo :fn (fn [_ _ _] [[] [] (m/schema :any)])})))))
+  (binding [*ns* (the-ns this-nsym)]
+    (is (= :any (m/compact-form :any))))
+  )


### PR DESCRIPTION
No benefit to doing this in malli, should just be a simple pretty-printer and manipulate the edn directly for alternative forms.

TODO
- [x] invert `:aliases` map so aliases are keys
- [ ] detect ambiguities
- [ ] hook up parsing compact forms
- [ ] make pretty printer that preserves `::` syntax (edamame?)
- [ ] allow both `::` and `:` to exist in the same printed (or actual?) form to resolve ambiguities

```
    (is (= [:tuple
            {:aliases {:malli.core-test :_, :malli.generator :mg}
             :registry {:_/a [:ref :_/b],
                        :_/b :mg/gen,
                        :mg/gen :_/a}}
            :_/a :_/b]
           (m/compact-form [:tuple
                            {:registry {::a [:ref ::b]
                                        ::b ::mg/gen
                                        ::mg/gen ::a}}
                            ::a ::b])))
```