### PR TITLE
`:instance`

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -8,7 +8,8 @@
             [clojure.test.check.properties :as prop]
             [clojure.test.check.random :as random]
             [clojure.test.check.rose-tree :as rose]
-            [clojure.reflect :as reflect]
+            #?@(:bb []
+                :clj [[clojure.reflect :as reflect]])
             [malli.core :as m]
             [malli.registry :as mr]
             [malli.util :as mu]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -513,7 +513,7 @@
 (comment
   (class-generator-via-reflection java.io.File nil)
   (class-generator-via-reflection String nil)
-  (sample (instance-generator [:instance java.io.File] nil))
+  (sample [:instance java.io.File])
   (reflect/type-reflect Class)
   (mapv class (sample [:instance java.io.File]))
   )

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -414,7 +414,7 @@
    :clj (defn- type-name->Class ^Class [type-name]
           (case type-name
             ;;FIXME proper impl !!
-            byte<> byte/1
+            byte<> (class (byte-array []))
             int Integer/TYPE
             (do
               (assert (not (str/ends-with? (name type-name) "<>"))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3637,3 +3637,12 @@
   (testing "print Schema"
     (is (= "[:map [:x :int]]"
            (pr-str (m/schema [:map [:x :int]]))))))
+
+(deftest instance-schema-test
+  #?(:clj
+     (do (is (m/validate [:instance java.io.File] (java.io.File. "a")))
+         (let [s (m/schema [:instance java.io.File])]
+           (is (= {:schema s,
+                   :value "a",
+                   :errors [{:path [0], :in [], :schema s, :value "a"}]}
+                  (m/explain s "a")))))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1142,4 +1142,5 @@
   (is (every? empty? (mg/sample empty?))))
 
 (deftest instance-generator-test
-  #(:clj (mg/sample [:instance java.io.File])))
+  #(:clj (is (= (mapv java.io.File/.getName (mg/sample [:instance java.io.File] {:seed 0}))
+                ["" "6" "" "0" "" "Sb" "Bfv33" "hLM4T" "2j3Yk3" "jHYY5y3"]))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1140,3 +1140,6 @@
 
 (deftest empty?-generator-test
   (is (every? empty? (mg/sample empty?))))
+
+(deftest instance-generator-test
+  #(:clj (mg/sample [:instance java.io.File])))


### PR DESCRIPTION
Adds a new schema `[:instance Class]` that accepts arbitrary classes. Compiles an efficient predicate for validation and features automatic generators by using reflection to look up constructors for classes.

Examples:

```clojure
(deftest instance-schema-test
  #?(:clj
     (do (is (m/validate [:instance java.io.File] (java.io.File. "a")))
         (let [s (m/schema [:instance java.io.File])]
           (is (= {:schema s,
                   :value "a",
                   :errors [{:path [0], :in [], :schema s, :value "a"}]}
                  (m/explain s "a")))))))

(deftest instance-generator-test
  #(:clj (is (= (mapv java.io.File/.getName (mg/sample [:instance java.io.File] {:seed 0}))
                ["" "6" "" "0" "" "Sb" "Bfv33" "hLM4T" "2j3Yk3" "jHYY5y3"]))))
```